### PR TITLE
Upgrade to Netty 4.1.50.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
     <mockito.version>2.27.0</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <netty.version>4.1.48.Final</netty.version>
+    <netty.version>4.1.50.Final</netty.version>
     <jetty.version>9.4.24.v20191120</jetty.version>
     <jackson.version>2.10.3</jackson.version>
     <json.version>1.1.1</json.version>


### PR DESCRIPTION
Hi

Package Owner: Shweta Singh

Patch Details : Modified pom.xml to update netty version to '4.1.50.Final'

Testing Detail:
Verified working by executing 'mvn test' command and all test cases are running fine on x86 and aarch64 both platforms.

PR Description :
- Upgrade Netty to its latest version 4.1.50.Final which includes both security fixes and AArch64 performance improvements
Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html
- Upgraded surefire to 3.0.0-M5 due to compatibility

Signed-off-by: odidev odidev@puresoftware.com